### PR TITLE
DEC-1383 Remove dependency on illuminate/cache for Laravel 10 compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,7 @@
         "php-http/discovery": "^1.9",
         "php-http/curl-client": "^2.1",
         "bretterer/iso_duration_converter": "^0.1.0",
-        "ext-json": "*",
-        "illuminate/cache": "^8.83.1 || ^9.0"
+        "ext-json": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0 ",

--- a/src/Adaptors/FirebasePhpJwt.php
+++ b/src/Adaptors/FirebasePhpJwt.php
@@ -19,7 +19,6 @@ namespace Okta\JwtVerifier\Adaptors;
 
 use Carbon\Carbon;
 use Firebase\JWT\JWT as FirebaseJWT;
-use Illuminate\Cache\ArrayStore;
 use Firebase\JWT\Key;
 use Okta\JwtVerifier\Jwt;
 use Okta\JwtVerifier\Request;
@@ -40,11 +39,11 @@ class FirebasePhpJwt implements Adaptor
      */
     private $leeway;
 
-    public function __construct(Request $request = null, int $leeway = 120, CacheInterface $cache = null)
+    public function __construct(Request $request = null, int $leeway = 120, CacheInterface $cache)
     {
         $this->request = $request ?: new Request();
         $this->leeway = $leeway ?: 120;
-        $this->cache = $cache ?: new \Illuminate\Cache\Repository(new ArrayStore(true));
+        $this->cache = $cache;
     }
 
     public function clearCache(string $jku)


### PR DESCRIPTION
The illuminate/cache dependency was only used to provide a default cache, but the dependency made the library incompatible with Laravel 10. Removed the dependency and made the cache a required parameter.