### PR TITLE
HRT-1706 Fix warning from optional param coming after required param

### DIFF
--- a/src/Adaptors/FirebasePhpJwt.php
+++ b/src/Adaptors/FirebasePhpJwt.php
@@ -39,7 +39,7 @@ class FirebasePhpJwt implements Adaptor
      */
     private $leeway;
 
-    public function __construct(Request $request = null, int $leeway = 120, CacheInterface $cache)
+    public function __construct(Request $request = null, int $leeway = 120, CacheInterface $cache = null)
     {
         $this->request = $request ?: new Request();
         $this->leeway = $leeway ?: 120;


### PR DESCRIPTION
Fixes warning:
```
dev.WARNING: Optional parameter $leeway declared before required parameter $cache is implicitly treated as a required parameter in /app/vendor/okta/jwt-verifier/src/Adaptors/FirebasePhpJwt.php on line 42
```